### PR TITLE
Setup pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+    -   id: check-yaml
+    -   id: check-toml
+    -   id: requirements-txt-fixer
+    -   id: check-docstring-first
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.12.9
+  hooks:
+    # Run the linter.
+    - id: ruff-check
+      args: ["--select", "F,I", "--fix"]
+    # Run the formatter.
+    - id: ruff-format

--- a/api/server.py
+++ b/api/server.py
@@ -1,9 +1,8 @@
+from dareplane_utils.default_server.server import DefaultServer
 from fire import Fire
 
-from dareplane_utils.default_server.server import DefaultServer
-
-from passthrough_decoder.utils.logging import logger
 from passthrough_decoder.main import get_main_thread
+from passthrough_decoder.utils.logging import logger
 
 
 def main(port: int = 8080, ip: str = "127.0.0.1", loglevel: int = 10):


### PR DESCRIPTION
Sets up and runs pre-commit hooks. 

One issue could not be auto-fixed: `sleep_s` is imported twice from different modules. @matthiasdold which implementation should be preferred?

https://github.com/bsdlab/dp-passthrough/blob/3c6c0e6412815c50159df6a4da4e0c3a4de8154a/passthrough_decoder/main.py#L15-L18